### PR TITLE
Fixed compilation error (typo)

### DIFF
--- a/SysLog.cpp
+++ b/SysLog.cpp
@@ -38,7 +38,7 @@ namespace SQLW
     void SysLog::databaseError(Database& db,Query& q,const std::string& str)
     {
         syslog(LOG_ERR, "%s: %s(%d)", str.c_str(),q.GetError().c_str(),q.GetErrno());
-        syslog(LOG_ERR, "QUERY: \"%s\"", q.GetLastQuery().c_str());
+        syslog(LOG_ERR, "QUERY: \"%s\"", q.getLastQuery().c_str());
     }
 
 } // namespace SQLW


### PR DESCRIPTION
The method getLastQuery was misspelled with a capital G, causing a compilation error.
You might consider changing some names to have a consistent case (at the moment some methods are camel-cased, like getResult, and some have a capital first letter, like GetError)